### PR TITLE
Add complete fields list for lsblk (listing disks)

### DIFF
--- a/core0/conf/disk.toml
+++ b/core0/conf/disk.toml
@@ -1,6 +1,6 @@
 [extension."disk.list"]
 binary = "sh"
-args = ["-c", "echo 20::: && lsblk -J -b && echo :::"]
+args = ["-c", "echo 20::: && lsblk -J -O -b && echo :::"]
 
 [extension."disk.mktable"]
 binary = "parted"


### PR DESCRIPTION
Improve the client disks list. This fix gives enable user to know if disks are SSD or not, etc.