### PR TITLE
Compile coreX into a static binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ branch = $(shell git rev-parse --abbrev-ref HEAD)
 revision = $(shell git rev-parse HEAD)
 dirty = $(shell test -n "`git diff --shortstat 2> /dev/null | tail -n1`" && echo "*")
 base = github.com/g8os/core0/base
-ldflags = '-w -s -X $(base).Branch=$(branch) -X $(base).Revision=$(revision) -X $(base).Dirty=$(dirty)'
+ldflags = '-w -s -X $(base).Branch=$(branch) -X $(base).Revision=$(revision) -X $(base).Dirty=$(dirty) -extldflags "-static"'
 
 all: core0 coreX
 
@@ -13,7 +13,7 @@ core0: $(OUTPUT)
 	cd core0 && go build -ldflags $(ldflags) -o ../$(OUTPUT)/$@
 
 coreX: $(OUTPUT)
-	cd coreX && go build -ldflags $(ldflags) -o ../$(OUTPUT)/$@
+	cd coreX && CGO_ENABLED=0 GOOS=linux go build -ldflags $(ldflags) -o ../$(OUTPUT)/$@
 
 
 $(OUTPUT):


### PR DESCRIPTION
Compile the coreX binary into a static binary. This allows containers to run without providing libraries to execute it.