### PR TITLE
Kvm portforwards

### DIFF
--- a/base/pm/process/process.go
+++ b/base/pm/process/process.go
@@ -45,4 +45,8 @@ type Stater interface {
 	Stats() *ProcessStats
 }
 
+type Signaler interface {
+	Signal(sig syscall.Signal) error
+}
+
 type ProcessFactory func(PIDTable, *core.Command) Process

--- a/base/pm/process/systemprocess.go
+++ b/base/pm/process/systemprocess.go
@@ -8,6 +8,7 @@ import (
 	psutils "github.com/shirou/gopsutil/process"
 	"io"
 	"os/exec"
+	"syscall"
 )
 
 type SystemCommandArguments struct {
@@ -138,6 +139,14 @@ func (process *systemProcessImpl) killChildren() {
 			log.Errorf("Failed to kill child process: %s", err)
 		}
 	}
+}
+
+func (process *systemProcessImpl) Signal(sig syscall.Signal) error {
+	if process.process != nil {
+		return syscall.Kill(int(process.process.Pid), sig)
+	}
+
+	return fmt.Errorf("process not found")
 }
 
 func (process *systemProcessImpl) Run() (<-chan *stream.Message, error) {

--- a/core0/kvm/domain.go
+++ b/core0/kvm/domain.go
@@ -155,11 +155,16 @@ type InterfaceDeviceModel struct {
 	Type string `xml:"type,attr"`
 }
 
+type InterfaceDeviceMac struct {
+	Address string `xml:"address,attr"`
+}
+
 type InterfaceDevice struct {
 	XMLName xml.Name              `xml:"interface"`
 	Type    InterfaceDeviceType   `xml:"type,attr"`
 	Source  InterfaceDeviceSource `xml:"source"`
 	Model   InterfaceDeviceModel  `xml:"model"`
+	Mac     InterfaceDeviceMac    `xml:"mac"`
 }
 
 type SerialDeviceType string

--- a/core0/main.go
+++ b/core0/main.go
@@ -14,7 +14,7 @@ import (
 	_ "github.com/g8os/core0/base/builtin"
 	_ "github.com/g8os/core0/core0/builtin"
 	"github.com/g8os/core0/core0/containers"
-	_ "github.com/g8os/core0/core0/kvm"
+	"github.com/g8os/core0/core0/kvm"
 	"github.com/g8os/core0/core0/options"
 	"github.com/g8os/core0/core0/stats"
 	"os"
@@ -132,6 +132,10 @@ func main() {
 	//start/register containers commands and process
 	if err := containers.ContainerSubsystem(sinks); err != nil {
 		log.Errorf("failed to intialize container subsystem", err)
+	}
+
+	if err := kvm.KVMSubsystem(); err != nil {
+		log.Errorf("failed to initialize kvm subsystem", err)
 	}
 
 	//start jobs sinks.

--- a/pyclient/g8core/client.py
+++ b/pyclient/g8core/client.py
@@ -917,7 +917,7 @@ class KvmManager:
         'images': [str],
         'cpu': int,
         'memory': int,
-        'bridge': typchk.Or(str, typchk.IsNone()),
+        'bridge': typchk.Or([str], typchk.IsNone()),
     })
 
     _destroy_chk = typchk.Checker({
@@ -928,6 +928,15 @@ class KvmManager:
         self._client = client
 
     def create(self, name, images, cpu=2, memory=512, bridge=None):
+        """
+
+        :param name: Name of the kvm domain
+        :param images: array of images to attach to the machine, where the first image is the boot device
+        :param cpu: number of vcpu cores
+        :param memory: memory in MiB
+        :param bridge: array of extra bridges to connect the domain with. the bridges must exist on the host
+        :return:
+        """
         args = {
             'name': name,
             'images': images,

--- a/pyclient/g8core/client.py
+++ b/pyclient/g8core/client.py
@@ -918,6 +918,10 @@ class KvmManager:
         'cpu': int,
         'memory': int,
         'bridge': typchk.Or([str], typchk.IsNone()),
+        'port': typchk.Or(
+            typchk.Map(int, int),
+            typchk.IsNone()
+        ),
     })
 
     _destroy_chk = typchk.Checker({
@@ -927,14 +931,18 @@ class KvmManager:
     def __init__(self, client):
         self._client = client
 
-    def create(self, name, images, cpu=2, memory=512, bridge=None):
+    def create(self, name, images, cpu=2, memory=512, port=None, bridge=None):
         """
 
         :param name: Name of the kvm domain
         :param images: array of images to attach to the machine, where the first image is the boot device
         :param cpu: number of vcpu cores
         :param memory: memory in MiB
+        :param port: A dict of host_port: container_port pairs
+                       Example:
+                        `port={8080: 80, 7000:7000}`
         :param bridge: array of extra bridges to connect the domain with. the bridges must exist on the host
+                       By default, vm is automatically added to a default bridge.
         :return:
         """
         args = {
@@ -943,6 +951,7 @@ class KvmManager:
             'cpu': cpu,
             'memory': memory,
             'bridge': bridge,
+            'port': port,
         }
         self._create_chk.check(args)
 


### PR DESCRIPTION
- Allow adding host config to dnsmasq on the fly
- Attach kvm domains to a default bridge with sequential IPs.
- Start socat for each port forward to the designated kvm

I first had to support adding host to dnsmasq on the fly.
and signal it to reload it's configuration so i can assign ips to hosts based on their macs.

Macs of vms i generate sequentially and attach them to default gateway (with dnsmasq attached). When i create a vm, i configure it's host on that bridge to give a certain IP
and then start socat process for each port forward for that IP