### PR TITLE
Supporting sending a signal to a process

### DIFF
--- a/base/pm/pm.go
+++ b/base/pm/pm.go
@@ -400,15 +400,17 @@ func (pm *PM) Killall() {
 	defer pm.runnersMux.Unlock()
 
 	for _, v := range pm.runners {
-		v.Kill()
+		v.Process().Kill()
 	}
 }
 
 //Kill kills a process by the cmd ID
-func (pm *PM) Kill(cmdID string) {
+func (pm *PM) Kill(cmdID string) error {
 	v, o := pm.runners[cmdID]
 	if o {
-		v.Kill()
+		return v.Process().Kill()
+	} else {
+		return fmt.Errorf("no process with id '%s' found", cmdID)
 	}
 }
 

--- a/base/pm/process/builtinprocess.go
+++ b/base/pm/process/builtinprocess.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/g8os/core0/base/pm/core"
 	"github.com/g8os/core0/base/pm/stream"
+	"syscall"
 )
 
 /*
@@ -90,6 +91,11 @@ func (process *internalProcess) Run() (<-chan *stream.Message, error) {
 /*
 Kill kills internal process (not implemented)
 */
-func (process *internalProcess) Kill() {
+func (process *internalProcess) Kill() error {
 	//you can't kill an internal process.
+	return nil
+}
+
+func (process *internalProcess) Signal(sig syscall.Signal) error {
+	return nil
 }

--- a/base/pm/process/extensionprocess.go
+++ b/base/pm/process/extensionprocess.go
@@ -5,6 +5,7 @@ import (
 	"github.com/g8os/core0/base/pm/core"
 	"github.com/g8os/core0/base/pm/stream"
 	"github.com/g8os/core0/base/utils"
+	"syscall"
 )
 
 type extensionProcess struct {
@@ -67,8 +68,12 @@ func (process *extensionProcess) Run() (<-chan *stream.Message, error) {
 	return process.system.Run()
 }
 
-func (process *extensionProcess) Kill() {
-	process.system.Kill()
+func (process *extensionProcess) Kill() error {
+	return process.system.Kill()
+}
+
+func (process *extensionProcess) Signal(sig syscall.Signal) error {
+	return process.system.Signal(sig)
 }
 
 func (process *extensionProcess) Stats() *ProcessStats {

--- a/base/pm/process/process.go
+++ b/base/pm/process/process.go
@@ -38,15 +38,12 @@ type ProcessStats struct {
 type Process interface {
 	Command() *core.Command
 	Run() (<-chan *stream.Message, error)
-	Kill()
+	Kill() error //==Signal(SIGTERM)
+	Signal(sig syscall.Signal) error
 }
 
 type Stater interface {
 	Stats() *ProcessStats
-}
-
-type Signaler interface {
-	Signal(sig syscall.Signal) error
 }
 
 type ProcessFactory func(PIDTable, *core.Command) Process

--- a/base/pm/runner.go
+++ b/base/pm/runner.go
@@ -20,7 +20,6 @@ const (
 type Runner interface {
 	Command() *core.Command
 	Run()
-	Kill()
 	Process() process.Process
 	Wait() *core.JobResult
 }

--- a/core0/builtin/bridge.go
+++ b/core0/builtin/bridge.go
@@ -228,12 +228,8 @@ func (b *bridgeMgr) addHost(cmd *core.Command) (interface{}, error) {
 		return nil, err
 	}
 
-	if signaler, ok := runner.Process().(process.Signaler); ok {
-		if err := signaler.Signal(syscall.SIGHUP); err != nil {
-			return nil, err
-		}
-	} else {
-		return nil, fmt.Errorf("not supported dnsmasq-process is not signalable")
+	if err := runner.Process().Signal(syscall.SIGHUP); err != nil {
+		return nil, err
 	}
 
 	return nil, nil

--- a/core0/kvm/manager.go
+++ b/core0/kvm/manager.go
@@ -357,7 +357,7 @@ func (m *kvmManager) forwardId(name string, host int) string {
 func (m *kvmManager) unPortForward(name string) {
 	for key, runner := range pm.GetManager().Runners() {
 		if strings.HasPrefix(key, fmt.Sprintf("kvm-socat-%s", name)) {
-			runner.Kill()
+			runner.Process().Kill()
 		}
 	}
 }


### PR DESCRIPTION
Also when signal is sent, the signal is by default sent
to the entire process group. This fixes a bug when u kill
a process and it doesn't kill its children