### PR TITLE
kvm: use libvirt bindings instead of virsh command, and add more actions

### DIFF
--- a/core0/kvm/domain.go
+++ b/core0/kvm/domain.go
@@ -80,8 +80,10 @@ const (
 )
 
 type Devices struct {
-	Emulator string `xml:"emulator"`
-	Devices  []Device
+	Emulator   string            `xml:"emulator"`
+	Disks      []DiskDevice      `xml:"disk"`
+	Interfaces []InterfaceDevice `xml:"interface"`
+	Devices    []Device
 }
 
 type DiskSource interface{}

--- a/core0/kvm/manager.go
+++ b/core0/kvm/manager.go
@@ -553,8 +553,13 @@ func (m *kvmManager) action(cmd *core.Command) (*libvirt.Domain, *libvirt.Connec
 
 	domain, err := conn.LookupDomainByUUIDString(params.UUID)
 	if err != nil {
+		conn.Close()
 		return nil, nil, params.UUID, fmt.Errorf("couldn't find domain with the uuid %s", params.UUID)
 	}
+	// we don't close the connection here because it is supposed to be used outside
+	// so we expect the caller to close it
+	// so if anything is to be added in this method that can return an error
+	// the connection has to be closed before the return
 	return domain, conn, params.UUID, err
 }
 
@@ -680,7 +685,6 @@ func (m *kvmManager) attachDisk(cmd *core.Command) (interface{}, error) {
 	if err := json.Unmarshal(*cmd.Arguments, &params); err != nil {
 		return nil, err
 	}
-	// FIXME: get the number of already attached disks
 	conn, err := libvirt.NewConnect("qemu:///system")
 	if err != nil {
 		return nil, fmt.Errorf("failed to start a qemu connection: %s", err)

--- a/pyclient/g8core/client.py
+++ b/pyclient/g8core/client.py
@@ -1235,7 +1235,7 @@ class KvmManager:
         ),
     })
 
-    _destroy_chk = typchk.Checker({
+    _domain_action_chk = typchk.Checker({
         'name': str,
     })
 
@@ -1279,9 +1279,74 @@ class KvmManager:
         args = {
             'name': name,
         }
-        self._destroy_chk.check(args)
+        self._domain_action_chk.check(args)
 
         self._client.sync('kvm.destroy', args)
+
+    def shutdown(self, name):
+        """
+        Shutdown a kvm domain by name
+        :param name: name of the kvm container (same as the used in create)
+        :return:
+        """
+        args = {
+            'name': name,
+        }
+        self._domain_action_chk.check(args)
+
+        self._client.sync('kvm.shutdown', args)
+
+    def reboot(self, name):
+        """
+        Reboot a kvm domain by name
+        :param name: name of the kvm container (same as the used in create)
+        :return:
+        """
+        args = {
+            'name': name,
+        }
+        self._domain_action_chk.check(args)
+
+        self._client.sync('kvm.reboot', args)
+
+    def reset(self, name):
+        """
+        Reset (Force reboot) a kvm domain by name
+        :param name: name of the kvm container (same as the used in create)
+        :return:
+        """
+        args = {
+            'name': name,
+        }
+        self._domain_action_chk.check(args)
+
+        self._client.sync('kvm.reset', args)
+
+    def pause(self, name):
+        """
+        Pause a kvm domain by name
+        :param name: name of the kvm container (same as the used in create)
+        :return:
+        """
+        args = {
+            'name': name,
+        }
+        self._domain_action_chk.check(args)
+
+        self._client.sync('kvm.pause', args)
+
+    def resume(self, name):
+        """
+        Resume a kvm domain by name
+        :param name: name of the kvm container (same as the used in create)
+        :return:
+        """
+        args = {
+            'name': name,
+        }
+        self._domain_action_chk.check(args)
+
+        self._client.sync('kvm.resume', args)
 
     def list(self):
         """

--- a/pyclient/g8core/client.py
+++ b/pyclient/g8core/client.py
@@ -1236,11 +1236,11 @@ class KvmManager:
     })
 
     _domain_action_chk = typchk.Checker({
-        'name': str,
+        'uuid': str,
     })
 
     _man_disk_action_chk = typchk.Checker({
-        'name': str,
+        'uuid': str,
         'media': {
             'type': typchk.Or(
                 typchk.Enum('disk', 'cdrom'),
@@ -1251,12 +1251,12 @@ class KvmManager:
     })
 
     _man_nic_action_chk = typchk.Checker({
-        'name': str,
+        'uuid': str,
         'bridge': str,
     })
 
     _limit_disk_io_action_chk = typchk.Checker({
-        'name': str,
+        'uuid': str,
         'targetname': str,
         'totalbytessecset': bool,
         'totalbytessec': int,
@@ -1317,7 +1317,7 @@ class KvmManager:
                         `port={8080: 80, 7000:7000}`
         :param bridge: array of extra bridges to connect the domain with. the bridges must exist on the host
                        By default, vm is automatically added to a default bridge.
-        :return:
+        :return: uuid of the virtual machine
         """
         args = {
             'name': name,
@@ -1329,151 +1329,152 @@ class KvmManager:
         }
         self._create_chk.check(args)
 
-        self._client.sync('kvm.create', args)
+        x = self._client.sync('kvm.create', args)
+        return x
 
-    def destroy(self, name):
+    def destroy(self, uuid):
         """
-        Destroy a kvm domain by name
-        :param name: name of the kvm container (same as the used in create)
+        Destroy a kvm domain by uuid
+        :param uuid: uuid of the kvm container (same as the used in create)
         :return:
         """
         args = {
-            'name': name,
+            'uuid': uuid,
         }
         self._domain_action_chk.check(args)
 
         self._client.sync('kvm.destroy', args)
 
-    def shutdown(self, name):
+    def shutdown(self, uuid):
         """
-        Shutdown a kvm domain by name
-        :param name: name of the kvm container (same as the used in create)
+        Shutdown a kvm domain by uuid
+        :param uuid: uuid of the kvm container (same as the used in create)
         :return:
         """
         args = {
-            'name': name,
+            'uuid': uuid,
         }
         self._domain_action_chk.check(args)
 
         self._client.sync('kvm.shutdown', args)
 
-    def reboot(self, name):
+    def reboot(self, uuid):
         """
-        Reboot a kvm domain by name
-        :param name: name of the kvm container (same as the used in create)
+        Reboot a kvm domain by uuid
+        :param uuid: uuid of the kvm container (same as the used in create)
         :return:
         """
         args = {
-            'name': name,
+            'uuid': uuid,
         }
         self._domain_action_chk.check(args)
 
         self._client.sync('kvm.reboot', args)
 
-    def reset(self, name):
+    def reset(self, uuid):
         """
-        Reset (Force reboot) a kvm domain by name
-        :param name: name of the kvm container (same as the used in create)
+        Reset (Force reboot) a kvm domain by uuid
+        :param uuid: uuid of the kvm container (same as the used in create)
         :return:
         """
         args = {
-            'name': name,
+            'uuid': uuid,
         }
         self._domain_action_chk.check(args)
 
         self._client.sync('kvm.reset', args)
 
-    def pause(self, name):
+    def pause(self, uuid):
         """
-        Pause a kvm domain by name
-        :param name: name of the kvm container (same as the used in create)
+        Pause a kvm domain by uuid
+        :param uuid: uuid of the kvm container (same as the used in create)
         :return:
         """
         args = {
-            'name': name,
+            'uuid': uuid,
         }
         self._domain_action_chk.check(args)
 
         self._client.sync('kvm.pause', args)
 
-    def resume(self, name):
+    def resume(self, uuid):
         """
-        Resume a kvm domain by name
-        :param name: name of the kvm container (same as the used in create)
+        Resume a kvm domain by uuid
+        :param uuid: uuid of the kvm container (same as the used in create)
         :return:
         """
         args = {
-            'name': name,
+            'uuid': uuid,
         }
         self._domain_action_chk.check(args)
 
         self._client.sync('kvm.resume', args)
 
-    def attachDisk(self, name, media):
+    def attachDisk(self, uuid, media):
         """
         Attach a disk to a mchine
-        :param name: name of the kvm container (same as the used in create)
+        :param uuid: uuid of the kvm container (same as the used in create)
         :param media: the media object to attach to the machine
                       media object is a dict of {url, and type} where type can be one of 'disk', or 'cdrom', or empty (default to disk)
                       examples: {'url': 'nbd+unix:///test?socket=/tmp/ndb.socket'}, {'type': 'cdrom': '/somefile.iso'}
         :return:
         """
         args = {
-            'name': name,
+            'uuid': uuid,
             'media': media,
         }
         self._man_disk_action_chk.check(args)
 
         self._client.sync('kvm.attachDisk', args)
 
-    def detachDisk(self, name, media):
+    def detachDisk(self, uuid, media):
         """
         Detach a disk from a machine
-        :param name: name of the kvm container (same as the used in create)
+        :param uuid: uuid of the kvm container (same as the used in create)
         :param media: the media object to attach to the machine
                       media object is a dict of {url, and type} where type can be one of 'disk', or 'cdrom', or empty (default to disk)
                       examples: {'url': 'nbd+unix:///test?socket=/tmp/ndb.socket'}, {'type': 'cdrom': '/somefile.iso'}
         :return:
         """
         args = {
-            'name': name,
+            'uuid': uuid,
             'media': media,
         }
         self._man_disk_action_chk.check(args)
 
         self._client.sync('kvm.detachDisk', args)
 
-    def addNic(self, name, bridge):
+    def addNic(self, uuid, bridge):
         """
         Add a nic to a machine
-        :param name: name of the kvm container (same as the used in create)
+        :param uuid: uuid of the kvm container (same as the used in create)
         :param bridge: the name of the bridge to add. the bridge must exist on the host
         :return:
         """
         args = {
-            'name': name,
+            'uuid': uuid,
             'bridge': bridge,
         }
         self._man_nic_action_chk.check(args)
 
         self._client.sync('kvm.addNic', args)
 
-    def removeNic(self, name, bridge):
+    def removeNic(self, uuid, bridge):
         """
         Remove a nic from a machine
-        :param name: name of the kvm container (same as the used in create)
+        :param uuid: uuid of the kvm container (same as the used in create)
         :param bridge: the name of the bridge to remove.
         :return:
         """
         args = {
-            'name': name,
+            'uuid': uuid,
             'bridge': bridge,
         }
         self._man_nic_action_chk.check(args)
 
         self._client.sync('kvm.removeNic', args)
 
-    def limitDiskIO(self, name, targetname, totalbytessecset=False, totalbytessec=0, readbytessecset=False, readbytessec=0, writebytessecset=False,
+    def limitDiskIO(self, uuid, targetname, totalbytessecset=False, totalbytessec=0, readbytessecset=False, readbytessec=0, writebytessecset=False,
                     writebytessec=0, totaliopssecset=False, totaliopssec=0, readiopssecset=False, readiopssec=0, writeiopssecset=False, writeiopssec=0,
                     totalbytessecmaxset=False, totalbytessecmax=0, readbytessecmaxset=False, readbytessecmax=0, writebytessecmaxset=False, writebytessecmax=0,
                     totaliopssecmaxset=False, totaliopssecmax=0, readiopssecmaxset=False, readiopssecmax=0, writeiopssecmaxset=False, writeiopssecmax=0,
@@ -1483,12 +1484,12 @@ class KvmManager:
                     sizeiopssec=0, groupnameset=False, groupname=''):
         """
         Remove a nic from a machine
-        :param name: name of the kvm container (same as the used in create)
+        :param uuid: uuid of the kvm container (same as the used in create)
         :param targetname: the name of the target disk
         :return:
         """
         args = {
-            'name': name,
+            'uuid': uuid,
             'targetname': targetname,
             'totalbytessecset': totalbytessecset,
             'totalbytessec': totalbytessec,

--- a/pyclient/g8core/client.py
+++ b/pyclient/g8core/client.py
@@ -1239,6 +1239,67 @@ class KvmManager:
         'name': str,
     })
 
+    _man_disk_action_chk = typchk.Checker({
+        'name': str,
+        'media': {
+            'type': typchk.Or(
+                typchk.Enum('disk', 'cdrom'),
+                typchk.Missing()
+            ),
+            'url': str,
+        },
+    })
+
+    _man_nic_action_chk = typchk.Checker({
+        'name': str,
+        'bridge': str,
+    })
+
+    _limit_disk_io_action_chk = typchk.Checker({
+        'name': str,
+        'targetname': str,
+        'totalbytessecset': bool,
+        'totalbytessec': int,
+        'readbytessecset': bool,
+        'readbytessec': int,
+        'writebytessecset': bool,
+        'writebytessec': int,
+        'totaliopssecset': bool,
+        'totaliopssec': int,
+        'readiopssecset': bool,
+        'readiopssec': int,
+        'writeiopssecset': bool,
+        'writeiopssec': int,
+        'totalbytessecmaxset': bool,
+        'totalbytessecmax': int,
+        'readbytessecmaxset': bool,
+        'readbytessecmax': int,
+        'writebytessecmaxset': bool,
+        'writebytessecmax': int,
+        'totaliopssecmaxset': bool,
+        'totaliopssecmax': int,
+        'readiopssecmaxset': bool,
+        'readiopssecmax': int,
+        'writeiopssecmaxset': bool,
+        'writeiopssecmax': int,
+        'totalbytessecmaxlengthset': bool,
+        'totalbytessecmaxlength': int,
+        'readbytessecmaxlengthset': bool,
+        'readbytessecmaxlength': int,
+        'writebytessecmaxlengthset': bool,
+        'writebytessecmaxlength': int,
+        'totaliopssecmaxlengthset': bool,
+        'totaliopssecmaxlength': int,
+        'readiopssecmaxlengthset': bool,
+        'readiopssecmaxlength': int,
+        'writeiopssecmaxlengthset': bool,
+        'writeiopssecmaxlength': int,
+        'sizeiopssecset': bool,
+        'sizeiopssec': int,
+        'groupnameset': bool,
+        'groupname': str,
+    })
+
     def __init__(self, client):
         self._client = client
 
@@ -1348,6 +1409,132 @@ class KvmManager:
 
         self._client.sync('kvm.resume', args)
 
+    def attachDisk(self, name, media):
+        """
+        Attach a disk to a mchine
+        :param name: name of the kvm container (same as the used in create)
+        :param media: the media object to attach to the machine
+                      media object is a dict of {url, and type} where type can be one of 'disk', or 'cdrom', or empty (default to disk)
+                      examples: {'url': 'nbd+unix:///test?socket=/tmp/ndb.socket'}, {'type': 'cdrom': '/somefile.iso'}
+        :return:
+        """
+        args = {
+            'name': name,
+            'media': media,
+        }
+        self._man_disk_action_chk.check(args)
+
+        self._client.sync('kvm.attachDisk', args)
+
+    def detachDisk(self, name, media):
+        """
+        Detach a disk from a machine
+        :param name: name of the kvm container (same as the used in create)
+        :param media: the media object to attach to the machine
+                      media object is a dict of {url, and type} where type can be one of 'disk', or 'cdrom', or empty (default to disk)
+                      examples: {'url': 'nbd+unix:///test?socket=/tmp/ndb.socket'}, {'type': 'cdrom': '/somefile.iso'}
+        :return:
+        """
+        args = {
+            'name': name,
+            'media': media,
+        }
+        self._man_disk_action_chk.check(args)
+
+        self._client.sync('kvm.detachDisk', args)
+
+    def addNic(self, name, bridge):
+        """
+        Add a nic to a machine
+        :param name: name of the kvm container (same as the used in create)
+        :param bridge: the name of the bridge to add. the bridge must exist on the host
+        :return:
+        """
+        args = {
+            'name': name,
+            'bridge': bridge,
+        }
+        self._man_nic_action_chk.check(args)
+
+        self._client.sync('kvm.addNic', args)
+
+    def removeNic(self, name, bridge):
+        """
+        Remove a nic from a machine
+        :param name: name of the kvm container (same as the used in create)
+        :param bridge: the name of the bridge to remove.
+        :return:
+        """
+        args = {
+            'name': name,
+            'bridge': bridge,
+        }
+        self._man_nic_action_chk.check(args)
+
+        self._client.sync('kvm.removeNic', args)
+
+    def limitDiskIO(self, name, targetname, totalbytessecset=False, totalbytessec=0, readbytessecset=False, readbytessec=0, writebytessecset=False,
+                    writebytessec=0, totaliopssecset=False, totaliopssec=0, readiopssecset=False, readiopssec=0, writeiopssecset=False, writeiopssec=0,
+                    totalbytessecmaxset=False, totalbytessecmax=0, readbytessecmaxset=False, readbytessecmax=0, writebytessecmaxset=False, writebytessecmax=0,
+                    totaliopssecmaxset=False, totaliopssecmax=0, readiopssecmaxset=False, readiopssecmax=0, writeiopssecmaxset=False, writeiopssecmax=0,
+                    totalbytessecmaxlengthset=False, totalbytessecmaxlength=0, readbytessecmaxlengthset=False, readbytessecmaxlength=0,
+                    writebytessecmaxlengthset=False, writebytessecmaxlength=0, totaliopssecmaxlengthset=False, totaliopssecmaxlength=0,
+                    readiopssecmaxlengthset=False, readiopssecmaxlength=0, writeiopssecmaxlengthset=False, writeiopssecmaxlength=0, sizeiopssecset=False,
+                    sizeiopssec=0, groupnameset=False, groupname=''):
+        """
+        Remove a nic from a machine
+        :param name: name of the kvm container (same as the used in create)
+        :param targetname: the name of the target disk
+        :return:
+        """
+        args = {
+            'name': name,
+            'targetname': targetname,
+            'totalbytessecset': totalbytessecset,
+            'totalbytessec': totalbytessec,
+            'readbytessecset': readbytessecset,
+            'readbytessec': readbytessec,
+            'writebytessecset': writebytessecset,
+            'writebytessec': writebytessec,
+            'totaliopssecset': totaliopssecset,
+            'totaliopssec': totaliopssec,
+            'readiopssecset': readiopssecset,
+            'readiopssec': readiopssec,
+            'writeiopssecset': writeiopssecset,
+            'writeiopssec': writeiopssec,
+            'totalbytessecmaxset': totalbytessecmaxset,
+            'totalbytessecmax': totalbytessecmax,
+            'readbytessecmaxset': readbytessecmaxset,
+            'readbytessecmax': readbytessecmax,
+            'writebytessecmaxset': writebytessecmaxset,
+            'writebytessecmax': writebytessecmax,
+            'totaliopssecmaxset': totaliopssecmaxset,
+            'totaliopssecmax': totaliopssecmax,
+            'readiopssecmaxset': readiopssecmaxset,
+            'readiopssecmax': readiopssecmax,
+            'writeiopssecmaxset': writeiopssecmaxset,
+            'writeiopssecmax': writeiopssecmax,
+            'totalbytessecmaxlengthset': totalbytessecmaxlengthset,
+            'totalbytessecmaxlength': totalbytessecmaxlength,
+            'readbytessecmaxlengthset': readbytessecmaxlengthset,
+            'readbytessecmaxlength': readbytessecmaxlength,
+            'writebytessecmaxlengthset': writebytessecmaxlengthset,
+            'writebytessecmaxlength': writebytessecmaxlength,
+            'totaliopssecmaxlengthset': totaliopssecmaxlengthset,
+            'totaliopssecmaxlength': totaliopssecmaxlength,
+            'readiopssecmaxlengthset': readiopssecmaxlengthset,
+            'readiopssecmaxlength': readiopssecmaxlength,
+            'writeiopssecmaxlengthset': writeiopssecmaxlengthset,
+            'writeiopssecmaxlength': writeiopssecmaxlength,
+            'sizeiopssecset': sizeiopssecset,
+            'sizeiopssec': sizeiopssec,
+            'groupnameset': groupnameset,
+            'groupname': groupname,
+        }
+        self._limit_disk_io_action_chk.check(args)
+
+        self._client.sync('kvm.limitDiskIO', args)
+
     def list(self):
         """
         List configured domains
@@ -1377,6 +1564,7 @@ class Client(BaseClient):
         self._btrfs_manager = BtrfsManager(self)
         self._zerotier = ZerotierManager(self)
         self._experimntal = Experimental(self)
+        self._kvm = KvmManager(self)
 
     @property
     def experimental(self):
@@ -1401,6 +1589,10 @@ class Client(BaseClient):
     @property
     def zerotier(self):
         return self._zerotier
+
+    @property
+    def kvm(self):
+        return self._kvm
 
     def raw(self, command, arguments):
         """

--- a/pyclient/g8core/client.py
+++ b/pyclient/g8core/client.py
@@ -1329,8 +1329,7 @@ class KvmManager:
         }
         self._create_chk.check(args)
 
-        x = self._client.sync('kvm.create', args)
-        return x
+        return self._client.sync('kvm.create', args)
 
     def destroy(self, uuid):
         """
@@ -1547,11 +1546,7 @@ class KvmManager:
 
 class Experimental:
     def __init__(self, client):
-        self._kvm = KvmManager(client)
-
-    @property
-    def kvm(self):
-        return self._kvm
+        pass
 
 
 class Client(BaseClient):


### PR DESCRIPTION
see #88 and #108 