### PR TITLE
Fixes #136 by truncating file for w mode

### DIFF
--- a/base/builtin/fs.go
+++ b/base/builtin/fs.go
@@ -116,7 +116,7 @@ func (fs *filesystem) mode(m string) (int, error) {
 		case 'r':
 			mode |= os.O_RDONLY
 		case 'w':
-			mode |= os.O_WRONLY
+			mode |= os.O_WRONLY | os.O_TRUNC
 		case '+':
 			mode |= os.O_RDWR
 		case 'x':

--- a/pyclient/g8core/client.py
+++ b/pyclient/g8core/client.py
@@ -178,7 +178,7 @@ class FilesystemManager:
 
         mode:
           'r' read only
-          'w' write only
+          'w' write only (truncate)
           '+' read/write
           'x' create if not exist
           'a' append


### PR DESCRIPTION
Add truncate flag when opening file in 'w' mode. For read-write without
truncate mode, just open the file in 'r+' mode. This follow the default
fopen implementation now