### PR TITLE
kvm-create: disk can be qcow or raw

### DIFF
--- a/core0/subsys/kvm/domain.go
+++ b/core0/subsys/kvm/domain.go
@@ -76,9 +76,6 @@ const (
 	DiskTypeVolume  DiskType = "volume"
 	DiskTypeNetwork DiskType = "network"
 
-	RawDisk   DiskDriverType = "raw"
-	Qcow2Disk DiskDriverType = "qcow2"
-
 	DiskDeviceTypeDisk  DiskDeviceType = "disk"
 	DiskDeviceTypeCDROM DiskDeviceType = "cdrom"
 )
@@ -119,7 +116,7 @@ type DiskTarget struct {
 }
 
 type DiskDriver struct {
-	Type DiskDriverType `xml:"type,attr"`
+	Type DiskDriverType `xml:"type,attr,omitempty"`
 }
 
 type DiskDevice struct {

--- a/core0/subsys/kvm/domain.go
+++ b/core0/subsys/kvm/domain.go
@@ -68,12 +68,16 @@ type Domain struct {
 
 type DiskType string
 type DiskDeviceType string
+type DiskDriverType string
 
 const (
 	DiskTypeFile    DiskType = "file"
 	DiskTypeDir     DiskType = "dir"
 	DiskTypeVolume  DiskType = "volume"
 	DiskTypeNetwork DiskType = "network"
+
+	RawDisk   DiskDriverType = "raw"
+	Qcow2Disk DiskDriverType = "qcow2"
 
 	DiskDeviceTypeDisk  DiskDeviceType = "disk"
 	DiskDeviceTypeCDROM DiskDeviceType = "cdrom"
@@ -114,12 +118,17 @@ type DiskTarget struct {
 	Bus string `xml:"bus,attr"`
 }
 
+type DiskDriver struct {
+	Type DiskDriverType `xml:"type,attr"`
+}
+
 type DiskDevice struct {
 	XMLName xml.Name       `xml:"disk"`
 	Type    DiskType       `xml:"type,attr"`
 	Device  DiskDeviceType `xml:"device,attr"`
 	Source  DiskSource     `xml:"source"`
 	Target  DiskTarget     `xml:"target"`
+	Driver  DiskDriver     `xml:"driver"`
 }
 
 type GraphicsDeviceType string

--- a/core0/subsys/kvm/manager.go
+++ b/core0/subsys/kvm/manager.go
@@ -118,9 +118,10 @@ func KVMSubsystem(conmgr containers.ContainerManager) error {
 }
 
 type Media struct {
-	URL  string         `json:"url"`
-	Type DiskDeviceType `json:"type"`
-	Bus  string         `json:"bus"`
+	URL        string         `json:"url"`
+	Type       DiskDeviceType `json:"type"`
+	DriverType DiskDriverType `json:"driver_type"`
+	Bus        string         `json:"bus"`
 }
 
 type Nic struct {
@@ -399,6 +400,11 @@ func (m *kvmManager) mkDisk(idx int, media Media) DiskDevice {
 	disk.Target.Bus = "virtio"
 	if media.Bus != "" {
 		disk.Target.Bus = media.Bus
+	}
+
+	disk.Driver.Type = "raw"
+	if media.DriverType == Qcow2Disk {
+		disk.Driver.Type = "qcow2"
 	}
 
 	//hack for cdrom, because it doesn't work well with virtio

--- a/core0/subsys/kvm/manager.go
+++ b/core0/subsys/kvm/manager.go
@@ -118,10 +118,9 @@ func KVMSubsystem(conmgr containers.ContainerManager) error {
 }
 
 type Media struct {
-	URL        string         `json:"url"`
-	Type       DiskDeviceType `json:"type"`
-	DriverType DiskDriverType `json:"driver_type"`
-	Bus        string         `json:"bus"`
+	URL  string         `json:"url"`
+	Type DiskDeviceType `json:"type"`
+	Bus  string         `json:"bus"`
 }
 
 type Nic struct {
@@ -392,17 +391,12 @@ func getDiskType(path string) string {
 	result := runner.Wait()
 	if result.State != core.StateSuccess {
 		return "raw"
-	} else {
-		var params QemuImgInfoResult
-		if err := json.Unmarshal([]byte(result.Streams[0]), &params); err != nil {
-			fmt.Println("%v", err)
-			return "raw2"
-		} else {
-			return params.Format
-		}
-
 	}
-
+	var params QemuImgInfoResult
+	if err := json.Unmarshal([]byte(result.Streams[0]), &params); err != nil {
+		return "raw"
+	}
+	return params.Format
 }
 
 func (m *kvmManager) mkFileDisk(idx int, u *url.URL) DiskDevice {

--- a/core0/subsys/kvm/manager.go
+++ b/core0/subsys/kvm/manager.go
@@ -265,6 +265,10 @@ type LastStatistics struct {
 	Epoch int64   `json:"m_epoch"`
 }
 
+type QemuImgInfoResult struct {
+	Format string `json:"format"`
+}
+
 func StateToString(state libvirt.DomainState) string {
 	var res string
 	switch state {
@@ -369,6 +373,38 @@ func (m *kvmManager) mkNBDDisk(idx int, u *url.URL) DiskDevice {
 	}
 }
 
+func getDiskType(path string) string {
+	cmd := &core.Command{
+		ID:      uuid.New(),
+		Command: process.CommandSystem,
+		Arguments: core.MustArguments(
+			process.SystemCommandArguments{
+				Name: "qemu-img",
+				Args: []string{"info", "--output=json", path},
+			},
+		),
+	}
+
+	runner, err := pm.GetManager().RunCmd(cmd)
+	if err != nil {
+		return "raw"
+	}
+	result := runner.Wait()
+	if result.State != core.StateSuccess {
+		return "raw"
+	} else {
+		var params QemuImgInfoResult
+		if err := json.Unmarshal([]byte(result.Streams[0]), &params); err != nil {
+			fmt.Println("%v", err)
+			return "raw2"
+		} else {
+			return params.Format
+		}
+
+	}
+
+}
+
 func (m *kvmManager) mkFileDisk(idx int, u *url.URL) DiskDevice {
 	target := "vd" + string(97+idx)
 	return DiskDevice{
@@ -378,6 +414,9 @@ func (m *kvmManager) mkFileDisk(idx int, u *url.URL) DiskDevice {
 		},
 		Source: DiskSourceFile{
 			File: u.String(),
+		},
+		Driver: DiskDriver{
+			Type: DiskDriverType(getDiskType(u.Path)),
 		},
 	}
 }
@@ -400,11 +439,6 @@ func (m *kvmManager) mkDisk(idx int, media Media) DiskDevice {
 	disk.Target.Bus = "virtio"
 	if media.Bus != "" {
 		disk.Target.Bus = media.Bus
-	}
-
-	disk.Driver.Type = "raw"
-	if media.DriverType == Qcow2Disk {
-		disk.Driver.Type = "qcow2"
 	}
 
 	//hack for cdrom, because it doesn't work well with virtio

--- a/pyclient/g8core/client.py
+++ b/pyclient/g8core/client.py
@@ -1282,6 +1282,10 @@ class KvmManager:
                 typchk.Enum('disk', 'cdrom'),
                 typchk.Missing()
             ),
+            'driver_type': typchk.Or(
+                typchk.Enum('qcow2', 'raw'),
+                typchk.Missing()
+            ),
             'url': str,
         }],
         'cpu': int,
@@ -1374,7 +1378,8 @@ class KvmManager:
         """
         :param name: Name of the kvm domain
         :param media: array of media objects to attach to the machine, where the first object is the boot device
-                      each media object is a dict of {url, and type} where type can be one of 'disk', or 'cdrom', or empty (default to disk)
+                      each media object is a dict of {url, type and driver_type} where type can be one of 'disk', or 'cdrom', or empty (default to disk)
+                      and the driver_type is either raw or qcow2 when applicable
                       example: [{'url': 'nbd+unix:///test?socket=/tmp/ndb.socket'}, {'type': 'cdrom': '/somefile.iso'}
         :param cpu: number of vcpu cores
         :param memory: memory in MiB

--- a/pyclient/g8core/client.py
+++ b/pyclient/g8core/client.py
@@ -1282,10 +1282,6 @@ class KvmManager:
                 typchk.Enum('disk', 'cdrom'),
                 typchk.Missing()
             ),
-            'driver_type': typchk.Or(
-                typchk.Enum('qcow2', 'raw'),
-                typchk.Missing()
-            ),
             'url': str,
         }],
         'cpu': int,
@@ -1378,8 +1374,7 @@ class KvmManager:
         """
         :param name: Name of the kvm domain
         :param media: array of media objects to attach to the machine, where the first object is the boot device
-                      each media object is a dict of {url, type and driver_type} where type can be one of 'disk', or 'cdrom', or empty (default to disk)
-                      and the driver_type is either raw or qcow2 when applicable
+                      each media object is a dict of {url, type} where type can be one of 'disk', or 'cdrom', or empty (default to disk)
                       example: [{'url': 'nbd+unix:///test?socket=/tmp/ndb.socket'}, {'type': 'cdrom': '/somefile.iso'}
         :param cpu: number of vcpu cores
         :param memory: memory in MiB


### PR DESCRIPTION
see #175 
now you can pass driver_type to explicitly specify if it is raw or qcow2.